### PR TITLE
Fixing RRC link and typos

### DIFF
--- a/_outline_template.html
+++ b/_outline_template.html
@@ -24,4 +24,4 @@
         <script src="assets/js/jquery.min.js"></script>
         <script src="assets/bootstrap/js/bootstrap.min.js"></script>
     </body>
-</html
+</html>

--- a/header.html
+++ b/header.html
@@ -29,13 +29,13 @@
             </a>
             <ul class="dropdown-menu">
               <li style="width:100%"><a href="runbook_how_to.html">How to add a runbook!</a></li>
-              <li style="width:100%"><a href="runbook_how_to_github.html">Github Basics</a></li>
+              <li style="width:100%"><a href="runbook_how_to_github.html">GitHub Basics</a></li>
             </ul>
           </li>
         </ul>
         <div class="collapse navbar-collapse" id="navcol-1">
           <ul class="nav navbar-nav navbar-right">
-              <li role="presentation"><a href="http://blogs.rrc.ca/informationsystems"/>ACE @ RRC </a></li>
+              <li role="presentation"><a target="_blank" href="https://www.rrc.ca/informationsystems"/>ACE @ RRC </a></li>
               <li role="presentation"><a href="#" data-toggle="modal" data-target="#contactUs">Contact us</a></li>
               <li role="presentation"><a target="_blank" href="https://discord.gg/RXySZQE"><img class="img-rounded" src="assets/img/discord-logo.png" style="width:110px; height: 35px;"/></a></li>
           </ul>

--- a/index.html
+++ b/index.html
@@ -22,7 +22,7 @@
                     <h3>Bits and Bytes Association</h3>
                     <h4>Fall 2020</h4>
                     <p>
-                        The Bits & Bytes Association (BBA) was created to improve communication between students and staff to enhance the
+                        The Bits and Bytes Association (BBA) was created to improve communication between students and staff to enhance the
                         quality of education for Introduction to Business Information Technology (IBIT), Business Information Technology
                         (BIT), Business Technology Management (BTM) and Information Security (IS) programs offered at Red River College through the Applied Computer Education (ACE) department.
                         Since its inception in 2015, BBA has grown to over 100 members today and continutes to climb steadily. If you would like to join the Bits and Bytes, You can join our <a href="https://discord.gg/RXySZQE">Discord</a>!
@@ -38,4 +38,4 @@
         <script src="assets/js/jquery.min.js"></script>
         <script src="assets/bootstrap/js/bootstrap.min.js"></script>
     </body>
-</html
+</html>

--- a/ourstory.html
+++ b/ourstory.html
@@ -26,7 +26,7 @@
                     <h3>Our Story</h3>
                 </div>
                 <div class="col-md-9 col-md-offset-0 post-body">
-                    <p>The Bits & Bytes Association (BBA) was created to improve communication between students and staff to enhance the quality of education for Introduction to Business Information Technology (IBIT), Business Information Technology (BIT) and Business Technology Management (BTM) programs offered at Red River College through the Applied Computer Education (ACE) department. Since its inception in 2015, BBA has grown to over 100 members today and continutes to climb steadily.</p>
+                    <p>The Bits and Bytes Association (BBA) was created to improve communication between students and staff to enhance the quality of education for Introduction to Business Information Technology (IBIT), Business Information Technology (BIT) and Business Technology Management (BTM) programs offered at Red River College through the Applied Computer Education (ACE) department. Since its inception in 2015, BBA has grown to over 100 members today and continues to climb steadily.</p>
                 </div>
             </div>
             <div class="row">
@@ -34,7 +34,7 @@
                     <h3>Get Involved</h3>
                 </div>
                 <div class="col-md-9 col-md-offset-0 post-body">
-                    <p>Participation in the Bits & Bytes Association is proven to increase the skills required to perform in industry today. However, we understand that there are other committments, assignments and the need for personal time. Joining us is optional and you are welcome to engage as much or as little as you want.</p>
+                    <p>Participation in the Bits and Bytes Association is proven to increase the skills required to perform in industry today. However, we understand that there are other commitments, assignments and the need for personal time. Joining us is optional and you are welcome to engage as much or as little as you want.</p>
                     <ul>
                         <!-- Add relevant links where applicable! -->
                         <li>Come to our general meetings</li>
@@ -52,10 +52,10 @@
             <div class="socialnavigation">
             	<ul>
             		<li><a href="mailto:info@bitsandbytesassociation.ca"><img src="assets/icons/email.png" width="50"></a></li>
-            		<li><a href="https://discord.gg/RXySZQE"><img src="assets/icons/discord-dark.png" width="50"></a></li>
-            		<li><a href="https://twitter.com/rrcbba"><img src="assets/icons/twitter.png" width="50"></a></li>
-            		<li><a href="https://www.instagram.com/rrcbba/"><img src="assets/icons/instagram.png" width="50"></a></li>
-            		<li><a href="https://www.facebook.com/rrcbitsbytes/"><img src="assets/icons/facebook.png" width="50"></a></li>
+            		<li><a href="https://discord.gg/RXySZQE" target="_blank"><img src="assets/icons/discord-dark.png" width="50"></a></li>
+            		<li><a href="https://twitter.com/rrcbba" target="_blank"><img src="assets/icons/twitter.png" width="50"></a></li>
+            		<li><a href="https://www.instagram.com/rrcbba/" target="_blank"><img src="assets/icons/instagram.png" width="50"></a></li>
+            		<li><a href="https://www.facebook.com/rrcbitsbytes/" target="_blank"><img src="assets/icons/facebook.png" width="50"></a></li>
             	</ul>
             </div>
             </div>

--- a/runbook_how_to.html
+++ b/runbook_how_to.html
@@ -17,16 +17,16 @@
           <h3>Have a runbook idea to add?</h3>
           <p>The purpose of these runbooks is to help future students with common problems that may not be covered soon enough
           or at all, in their courses. These are student developed and written. So, if you have an idea, here is the process to get your
-          runbook added</p>
+          runbook added:</p>
           <ol>
-            <li><a href="https://github.com/bits-and-bytes-association/rrc-bba-website">Fork the BBA Repo to your github account</a> by <a href="https://opensource.com/article/19/7/create-pull-request-github">these instructions</a></li>
-            <li>Create a new HTML doc for your runbook, prefixed with runbook. I.e "runbook_how_to_github.html"</li>
-            <li>Copy the code from the _outline_template.html over to your new runbook file(this ensures consitant look, headers, and footers)</li>
-            <li>Write the runbbok in the section where it says "put your content here"</li>
+            <li><a href="https://github.com/bits-and-bytes-association/rrc-bba-website" target="_blank">Fork the BBA Repo to your github account</a> by <a href="https://opensource.com/article/19/7/create-pull-request-github" target="_blank">these instructions</a></li>
+            <li>Create a new HTML doc for your runbook, prefixed with runbook. i.e "runbook_how_to_github.html"</li>
+            <li>Copy the code from the _outline_template.html over to your new runbook file (this ensures consistent look, headers, and footers)</li>
+            <li>Write the runbook in the section where it says "put your content here"</li>
             <li>After you have finished, add your runbook to the runbook navbar link (Found in the header.html)</li>
             <li>Open a pull request for the BBA to approve!</li>
           </ol>
-          <p>If you are unsure if a subject is appropriate for a runbook or not, please feel free to reach out in our discord and ask us! I promise we are friendly</p>
+          <p>If you are unsure if a subject is appropriate for a runbook or not, please feel free to reach out in our Discord and ask us! I promise we are friendly.</p>
         </div>
         <div w3-include-html="./footer.html"></div>
         <script src="https://www.w3schools.com/lib/w3data.js"></script>
@@ -36,4 +36,4 @@
         <script src="assets/js/jquery.min.js"></script>
         <script src="assets/bootstrap/js/bootstrap.min.js"></script>
     </body>
-</html
+</html>


### PR DESCRIPTION
Hello, can you review these fixes? I fixed some minor spelling mistakes and inconsistencies. Also fixed some of the HTML tags that were missing the closing >. External links are updated to open in a new tab. 

I updated the broken ACE @ RRC link in the header to [https://www.rrc.ca/informationsystems](https://www.rrc.ca/informationsystems). Not sure what content it linked to before, but this is the homepage for the whole department.